### PR TITLE
--pictype (-p) now case insensitive

### DIFF
--- a/trunk/upp_wx/src/main.h
+++ b/trunk/upp_wx/src/main.h
@@ -127,7 +127,7 @@ static const wxCmdLineEntryDesc g_cmdLineDesc [] =
 {
 	{ wxCMD_LINE_SWITCH, "h", _("help"),        _("displays help on the command line parameters"), wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
 	{ wxCMD_LINE_SWITCH, "V", _("version"),     _("displays version information of usbpicprog") },
-	{ wxCMD_LINE_OPTION, "p", _("pictype"),     _("specify the pic type (eg -p=18F2550)"), wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
+	{ wxCMD_LINE_OPTION, "p", _("pictype"),     _("specify the pic type (case insensitive) (eg -p=18F2550)"), wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
 	{ wxCMD_LINE_SWITCH, "s", _("silent"),      _("do not display the hex file") },
 	{ wxCMD_LINE_SWITCH, "w", _("write"),       _("write the device") },
 	{ wxCMD_LINE_SWITCH, "r", _("read"),        _("read the device") },

--- a/trunk/upp_wx/src/pictype.cpp
+++ b/trunk/upp_wx/src/pictype.cpp
@@ -96,7 +96,7 @@ PicType PicType::FindPIC(wxString picTypeStr)
 {
     for (unsigned int i=0;i<s_arrSupported.size();i++)
     {
-		if (picTypeStr.compare(s_arrSupported[i].name)==0)
+		if (picTypeStr.CmpNoCase(s_arrSupported[i].name)==0)
         {
             // this is a supported PIC!
 


### PR DESCRIPTION
I think it's more useful if `--pictype` (`-p`) is case insensitive.
Not tested because I can't compile the whole project due to other issues.
