### PR TITLE
Pull VPP/#RESET down to GND when stopping target.

### DIFF
--- a/trunk/upp_wx/src/hardware.cpp
+++ b/trunk/upp_wx/src/hardware.cpp
@@ -1094,7 +1094,7 @@ bool Hardware::runTarget()
 bool Hardware::stopTarget()
 {
     if(m_hwCurrent != HW_UPP)return false;
-    if(setPinState(SUBCMD_PIN_VPP, PIN_STATE_FLOAT)<0)return false;
+    if(setPinState(SUBCMD_PIN_VPP, PIN_STATE_0V)<0)return false;
     if(setPinState(SUBCMD_PIN_VDD, PIN_STATE_FLOAT)<0)return false;
 	if(setPinState(SUBCMD_PIN_PGD, PIN_STATE_INPUT)<0)return false;
 	if(setPinState(SUBCMD_PIN_PGC, PIN_STATE_0V)<0)return false;


### PR DESCRIPTION
Since the most common thing is having a pull-up resistor
on VPP/#RESET pin, leaving VPP floating doesn't hold the target
in reset state in case of self-powered targets.
